### PR TITLE
Fix bash snippet for cloning with a PAT

### DIFF
--- a/docs/repos/git/includes/personal-access-tokens.md
+++ b/docs/repos/git/includes/personal-access-tokens.md
@@ -166,8 +166,8 @@ To keep your token more secure, use credential managers so you don't have to ent
 In Bash, enter the following code.
 
 ```bash
-MY_PAT=yourPAT # replace "yourPAT" with ":PatStringFromWebUI"
-B64_PAT=$(printf "%s"":$MY_PAT" | base64)
+MY_PAT=yourPAT # replace "yourPAT" with "PatStringFromWebUI"
+B64_PAT=$(printf ":%s" "$MY_PAT" | base64)
 git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://dev.azure.com/yourOrgName/yourProjectName/_git/yourRepoName 
 ```
 


### PR DESCRIPTION
The example provided is totally wrong. Used as is, it doesn't work.

The main problem is that the comment tells the user to prefix their PAT with a  `:`, but then, on the next line, there is also a `:` added in the `printf`.  This ends up generating a wrong base64.

The printf is also completely wrong. No space between `"%s"` and `":$MY_PAT"`,  means it's just one string and no 2nd argument for the `"%s"`, making the  placeholder unused. The proper form is to have the `:` in the format string and  passing "$MY_PAT" as an argument.